### PR TITLE
Version number in library.properties is corrected.

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Grandeur
-version=1.0.0
+version=1.0.2
 author=Grandeur Technologies
 maintainer=Grandeur Technologies <hi@grandeur.tech>
 sentence=Let your arduinos and ESPs communicate with Grandeur in realtime.


### PR DESCRIPTION
We released 1.0.1 version but didn't update the version number in library.properties. Nothing can be done for that release now, but we can correct 1.1. 1.1 because there are breaking changes in this version like Class Hierarchies (`Grandeur::Project` instead of just Project) and change in acceptable callback structure for device.data().get() and device.data().set().